### PR TITLE
QFtp: Suppress warning about reading from closed QIODevice.

### DIFF
--- a/src/qftp/qftp.cpp
+++ b/src/qftp/qftp.cpp
@@ -744,7 +744,16 @@ void QFtpDTP::socketConnectionClosed()
         clearData();
     }
 
-    bytesFromSocket = socket->readAll();
+    // check if socket is open before reading data
+    if (socket->isOpen())
+    {
+        bytesFromSocket = socket->readAll();
+    }
+    else
+    {
+        bytesFromSocket.clear();
+    }
+    
 #if defined(QFTPDTP_DEBUG)
     qDebug("QFtpDTP::connectState(CsClosed)");
 #endif


### PR DESCRIPTION
Clear bytesFromSocket when the socket is not open instead of
reading in QFtpDTP::socketConnectionClosed(), which is connected
to QTcpSocket::disconnected().